### PR TITLE
Fix numeric errors

### DIFF
--- a/qiskit_qcgpu_provider/qasm_simulator.py
+++ b/qiskit_qcgpu_provider/qasm_simulator.py
@@ -308,9 +308,17 @@ class QCGPUQasmSimulator(BaseBackend):
         probabilities = np.reshape(np.sum(probabilities,
                                           axis=tuple(axis)),
                                    2 ** num_measured)
+
+        # Normalize probabilities when the ammount do not sum 1 because of numeric error
+        aux = []
+        prob_sum = sum(probabilities)
+
+        for i in probabilities:
+            aux.append(i/prob_sum)
+
         # Generate samples on measured qubits
         samples = self._local_random.choice(range(2 ** num_measured),
-                                            num_samples, p=probabilities)
+                                            num_samples, p=aux)
         # Convert to bit-strings
         memory = []
         for sample in samples:

--- a/qiskit_qcgpu_provider/qasm_simulator.py
+++ b/qiskit_qcgpu_provider/qasm_simulator.py
@@ -310,15 +310,15 @@ class QCGPUQasmSimulator(BaseBackend):
                                    2 ** num_measured)
 
         # Normalize probabilities when the ammount do not sum 1 because of numeric error
-        aux = []
+        normalized_probabilitites = []
         prob_sum = sum(probabilities)
 
         for i in probabilities:
-            aux.append(i/prob_sum)
+            normalized_probabilitites.append(i/prob_sum)
 
         # Generate samples on measured qubits
         samples = self._local_random.choice(range(2 ** num_measured),
-                                            num_samples, p=aux)
+                                            num_samples, p=normalized_probabilitites)
         # Convert to bit-strings
         memory = []
         for sample in samples:


### PR DESCRIPTION
## Context
During circuit execution with a huge amount of qubits, the circuit returns "probabilities do not sum 1".

## Fix
Just normalize the data before returns it.